### PR TITLE
Add hover effect to quotation table rows

### DIFF
--- a/src/app/vendedor/cotizaciones/page.tsx
+++ b/src/app/vendedor/cotizaciones/page.tsx
@@ -89,13 +89,22 @@ export default function HistorialCotizaciones() {
 
                         <tbody>
                         {data.map((c) => (
-                            <tr key={c.id} className="border-b last:border-b-0">
-                                <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">{c.fecha}</td>
-                                <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">{c.cliente}</td>
+                            <tr
+                                key={c.id}
+                                className="border-b last:border-b-0 hover:bg-gray-100 cursor-pointer transition-colors"
+                            >
+                                <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">
+                                    {c.fecha}
+                                </td>
+                                <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">
+                                    {c.cliente}
+                                </td>
                                 <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">
                                     <EstadoBadge estado={c.estado} />
                                 </td>
-                                <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">{c.total}</td>
+                                <td className="px-6 py-4 border-b border-b-[1px] border-b-[#EDEFEE]">
+                                    {c.total}
+                                </td>
                             </tr>
                         ))}
                         </tbody>


### PR DESCRIPTION
## Summary
- make quotation rows highlighted on hover so each entry appears clickable

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564e65192083208a4dfb399ca301c2