### PR TITLE
Fix Next.js build by removing invalid page export

### DIFF
--- a/src/app/vendedor/cotizaciones/page.tsx
+++ b/src/app/vendedor/cotizaciones/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
-import { useRouter } from 'next/navigation';
+import { QuotationTable } from './QuotationTable';
 import { FaCheck, FaClock, FaTimes } from 'react-icons/fa';
 
 /* ---------------------------------- */
@@ -119,50 +119,6 @@ const Pagination: React.FC<PaginationProps> = ({ page, totalPages, onChange }) =
         ▶
       </button>
     </div>
-  );
-};
-
-export const QuotationTable: React.FC<Props> = ({ cotizaciones, onRowClick }) => {
-  const router = useRouter();
-
-  if (cotizaciones.length === 0) {
-    return (
-      <div className="flex flex-col items-center py-16">
-        <img src="/empty-state.svg" alt="Sin cotizaciones" className="w-40 mb-4 opacity-70" />
-        <p className="text-gray-500 text-lg">No hay cotizaciones para mostrar.</p>
-      </div>
-    );
-  }
-
-  return (
-    <table className="min-w-full text-sm">
-      <thead>
-        <tr className="bg-gray-100">
-          <th className="px-6 py-3 text-left">Fecha</th>
-          <th className="px-6 py-3 text-left">Cliente</th>
-          <th className="px-6 py-3 text-left">RUT</th>
-          <th className="px-6 py-3 text-left">Estado</th>
-          <th className="px-6 py-3 text-left">Total</th>
-        </tr>
-      </thead>
-      <tbody>
-        {cotizaciones.map((c) => (
-          <tr
-            key={c.id}
-            className="cursor-pointer transition hover:bg-blue-50"
-            onClick={() => onRowClick ? onRowClick(c.id) : router.push(`/cotizaciones/${c.id}`)}
-          >
-            <td className="px-6 py-4 border-b border-gray-200">{c.fecha}</td>
-            <td className="px-6 py-4 border-b border-gray-200">{c.cliente}</td>
-            <td className="px-6 py-4 border-b border-gray-200">{c.rut}</td>
-            <td className="px-6 py-4 border-b border-gray-200">
-              <EstadoBadge estado={c.estado} />
-            </td>
-            <td className="px-6 py-4 border-b border-gray-200">{c.total}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
   );
 };
 


### PR DESCRIPTION
## Summary
- use `QuotationTable` component from its own file
- remove invalid named export from page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567aaf0f5c83209899a93e33fdbfd8