### PR TITLE
Fix lint issues in cotizaciones pages

### DIFF
--- a/src/app/vendedor/cotizaciones/QuotationTable.tsx
+++ b/src/app/vendedor/cotizaciones/QuotationTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
 
 interface Cotizacion {
     id: number;
@@ -35,7 +36,13 @@ export const QuotationTable: React.FC<Props> = ({ cotizaciones, onRowClick }) =>
     if (cotizaciones.length === 0) {
         return (
             <div className="flex flex-col items-center py-16">
-                <img src="/empty-state.svg" alt="Sin cotizaciones" className="w-40 mb-4 opacity-70" />
+                <Image
+                    src="/empty-state.svg"
+                    alt="Sin cotizaciones"
+                    width={160}
+                    height={160}
+                    className="w-40 mb-4 opacity-70"
+                />
                 <p className="text-gray-500 text-lg">No hay cotizaciones para mostrar.</p>
             </div>
         );

--- a/src/app/vendedor/cotizaciones/page.tsx
+++ b/src/app/vendedor/cotizaciones/page.tsx
@@ -25,10 +25,6 @@ interface PaginationProps {
   onChange: (page: number) => void;
 }
 
-interface Props {
-    cotizaciones: Cotizacion[];
-    onRowClick?: (id: number) => void;
-}
 
 const data: Cotizacion[] = [
     { id: 1, fecha: '10/05/2025', cliente: 'Cliente A', rut: "00000000-0", estado: 'Aprobada',  total: '26.500 $' },
@@ -72,22 +68,6 @@ const Chip = ({
     </div>
 );
 
-/* ---------------------------------- */
-/*  Badge según estado */
-/* ---------------------------------- */
-const EstadoBadge = ({ estado }: { estado: Cotizacion['estado'] }) => {
-    const variant = {
-        Aprobada:  'bg-green-100 text-green-700',
-        Pendiente: 'bg-yellow-100 text-yellow-700',
-        Rechazada: 'bg-red-100 text-red-700',
-    }[estado];
-
-    return (
-        <span className={`px-3 py-1 rounded-md text-xs font-semibold ${variant}`}>
-      {estado}
-    </span>
-    );
-};
 
 const Pagination: React.FC<PaginationProps> = ({ page, totalPages, onChange }) => {
   if (totalPages <= 1) return null;


### PR DESCRIPTION
## Summary
- handle empty state image with `next/image`
- remove unused interfaces and components that were causing lint errors

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856829060308320bc2890d9044d1d5b