### PR TITLE
Implement client context and maintenance message

### DIFF
--- a/src/app/admin/inventario/page.tsx
+++ b/src/app/admin/inventario/page.tsx
@@ -1,4 +1,6 @@
 //parche para accionar workflow ci
+import UnderConstruction from '@/components/UnderConstruction';
+
 export default function InventarioPage() {
-  return <div>Inventario</div>;
+  return <UnderConstruction />;
 }

--- a/src/app/vendedor/clientes/page.tsx
+++ b/src/app/vendedor/clientes/page.tsx
@@ -1,3 +1,5 @@
-export default function Clientes (){
-    return <div>Inventario</div>;
+import UnderConstruction from '@/components/UnderConstruction';
+
+export default function Clientes() {
+    return <UnderConstruction />;
 }

--- a/src/app/vendedor/dashboard/page.tsx
+++ b/src/app/vendedor/dashboard/page.tsx
@@ -1,3 +1,5 @@
-export default function Dashboard (){
-    return <div>Inventario</div>;
+import UnderConstruction from '@/components/UnderConstruction';
+
+export default function Dashboard() {
+    return <UnderConstruction />;
 }

--- a/src/app/vendedor/inventario/page.tsx
+++ b/src/app/vendedor/inventario/page.tsx
@@ -1,3 +1,5 @@
-export default function Inventario (){
-    return <div>Inventario</div>;
+import UnderConstruction from '@/components/UnderConstruction';
+
+export default function Inventario() {
+    return <UnderConstruction />;
 }

--- a/src/app/vendedor/page.tsx
+++ b/src/app/vendedor/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { FaSearch } from 'react-icons/fa';
@@ -8,6 +8,7 @@ import { FaSearch } from 'react-icons/fa';
 import { CLIENTES_DEMO, ClienteDemo } from '@/mock/mockClients';
 import ModalNuevoCliente, { ClienteForm } from '@/components/ModalNuevoCliente';
 import { useCustomer } from '@/context/ClienteContext';
+import { useCart } from '@/context/CartContext';
 
 export default function VendedorPage() {
     /* ------------------------------------------------------------- */
@@ -15,9 +16,16 @@ export default function VendedorPage() {
     /* ------------------------------------------------------------- */
     const router = useRouter();
     const { cliente, setCliente, clearCliente } = useCustomer();
+    const { clearCart } = useCart();
 
     const [query, setQuery] = useState('');
     const [openModal, setOpenModal] = useState(false);
+
+    // Limpiar contextos al entrar al Home
+    useEffect(() => {
+        clearCliente();
+        clearCart();
+    }, []);
 
     /* ------------------------------------------------------------- */
     /*  BÚSQUEDA DE CLIENTES                                         */
@@ -94,7 +102,7 @@ export default function VendedorPage() {
                                 onClick={clearCliente}
                                 className="cursor-pointer text-sm text-white hover:underline bg-orange-500 hover:bg-orange-600 px-3 py-1 rounded-md font-semibold"
                             >
-                                Cambiar cliente
+                                Cerrar ficha
                             </button>
                         </div>
 

--- a/src/app/vendedor/ventas/page.tsx
+++ b/src/app/vendedor/ventas/page.tsx
@@ -1,4 +1,6 @@
 
-export default function Ventas (){
-    return <div>Inventario</div>;
+import UnderConstruction from '@/components/UnderConstruction';
+
+export default function Ventas() {
+    return <UnderConstruction />;
 }

--- a/src/components/UnderConstruction.tsx
+++ b/src/components/UnderConstruction.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function UnderConstruction() {
+  return (
+    <div className="flex items-center justify-center h-full p-8">
+      <p className="text-center text-gray-700">
+        Este sitio está actualmente en construcción. Estamos trabajando para
+        brindarte la mejor experiencia. Vuelve pronto.
+      </p>
+    </div>
+  );
+}

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   ReactNode,
 } from 'react';
+import { useCustomer } from './ClienteContext';
 
 /* ---------- Tipos ---------- */
 
@@ -32,25 +33,28 @@ interface CartContextType {
 
 const CartContext = createContext<CartContextType | undefined>(undefined);
 
-const STORAGE_KEY = 'construtem-cart';
+const BASE_KEY = 'construtem-cart';
 
 /* ---------- Provider ---------- */
 
 export const CartProvider = ({ children }: { children: ReactNode }) => {
   const [cart, setCart] = useState<Product[]>([]);
+  const { cliente } = useCustomer();
+
+  const storageKey = `${BASE_KEY}-${cliente?.id ?? 'guest'}`;
 
   /* Cargar carrito almacenado (solo en cliente) */
   useEffect(() => {
-    if (typeof window === 'undefined') return;            // evita SSR
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) setCart(JSON.parse(stored));
-  }, []);
+    if (typeof window === 'undefined') return; // evita SSR
+    const stored = localStorage.getItem(storageKey);
+    setCart(stored ? JSON.parse(stored) : []);
+  }, [storageKey]);
 
   /* Guardar automáticamente cada vez que cambia */
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(cart));
-  }, [cart]);
+    localStorage.setItem(storageKey, JSON.stringify(cart));
+  }, [cart, storageKey]);
 
   /* ---------- Acciones ---------- */
 
@@ -79,7 +83,12 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
       setCart(prev => prev.filter(p => p.sku !== sku));
 
   /** Vacía el carrito */
-  const clearCart = () => setCart([]);
+  const clearCart = () => {
+    setCart([]);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(storageKey);
+    }
+  };
 
   /** Cambia la cantidad exacta; si es <1 lo quita */
   const updateQuantity = (sku: string, cantidad: number) =>


### PR DESCRIPTION
## Summary
- reset client and cart when returning to vendor home
- link cart storage to the selected client
- add reusable `UnderConstruction` component
- show construction message on incomplete pages
- label 'Cerrar ficha' for closing client info

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575fea1ffc83208edd02ac751d269a