### PR TITLE
Se añadió el ícono 2 en la card cuando no hay clientes seleccionados

### DIFF
--- a/src/components/NumberIcon.tsx
+++ b/src/components/NumberIcon.tsx
@@ -1,9 +1,9 @@
 import {useCotizacionFlow} from "@/contexts/CotizacionFlow";
 
-export default function NumberIcon({ number }: { number: number }) {
+export default function NumberIcon({ number, className }: { number: number, className?: string }) {
     const { state } = useCotizacionFlow();
     return (
-        <div onClick={()=>console.log(state)} className="flex items-center justify-center w-8 h-8 bg-blue-500 text-white font-semibold font-montserrat rounded-full left-1">
+        <div onClick={()=>console.log(state)} className={`${className} flex items-center justify-center w-8 h-8 bg-blue-500 text-white font-semibold font-montserrat rounded-full left-1`}>
             {number}
         </div>
     );

--- a/src/components/cotizacion/CotizacionBlocked.tsx
+++ b/src/components/cotizacion/CotizacionBlocked.tsx
@@ -2,14 +2,15 @@ import Image from 'next/image';
 import QuoteIcon from '@/styles/images/QuoteIcon.png';
 export default function CotizacionBlocked() {
 
-    return (
-        <div className={'flex flex-col h-full justify-center'}>
-            <div className="flex flex-col  h-full  items-center gap-[5px]">
+    return (<>
+        <div className={'flex items-center flex-col h-full justify-center'}>
+            <div className="my-auto h-fit flex flex-col items-center gap-[5px]">
             <Image src={QuoteIcon} alt={'Icono de cotización'} width={200} height={200}/>
             <div className={'w-84'}>
             <h2 className={'text-center text-[#033c86] font-semibold font-montserrat text-[24px]'}>Primero selecciona un cliente para ver o gestionar cotizaciones</h2>
             </div>
             </div>
         </div>
+    </>
     )
 }

--- a/src/components/cotizacion/CotizacionForm.tsx
+++ b/src/components/cotizacion/CotizacionForm.tsx
@@ -11,6 +11,7 @@ import { useAddressCheck } from '@/hooks/useAddressCheck'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import CotizacionHeader from "@/components/cotizacion/CotizacionHeader";
 import CotizacionBlocked from "@/components/cotizacion/CotizacionBlocked";
+import NumberIcon from "@/components/NumberIcon";
 
 
 
@@ -135,9 +136,14 @@ export const CotizacionForm: React.FC<Props> = ({
 
     /* ───────── Render ───────── */
     return (
-        <article className={`${state.clienteRut?'':'flex flex-col justify-center'} bg-white rounded-[10px] shadow px-8 py-6 space-y-4 shadow-[0_0_2px_rgba(0,0,0,0.25)] lg:min-h-[550px]`}>
+        <article className={`${state.clienteRut?'':'h-full relative flex flex-col'} bg-white rounded-[10px] shadow px-8 py-6 space-y-4 shadow-[0_0_2px_rgba(0,0,0,0.25)] lg:min-h-[550px]`}>
             {!state.clienteRut ? (
-                <CotizacionBlocked/>
+                <>
+                    <div className={`flex relative items-baseline`}>
+                    <NumberIcon number={2} className={'absolute'}/>
+                    </div>
+                    <CotizacionBlocked/>
+                </>
             ) : (
                 <>
             <CotizacionHeader/>

--- a/src/components/cotizacion/CotizacionHeader.tsx
+++ b/src/components/cotizacion/CotizacionHeader.tsx
@@ -39,7 +39,7 @@ export default function CotizacionHeader(){
     }
     return (
         <div className={'flex flex-col justify-between items-baseline mb-6 lg:flex-row lg:gap-0 gap-[20px] items-center'}>
-            <div className={'flex items-center gap-2'}>
+            <div className={'flex items-center gap-[20px]'}>
             <NumberIcon number={2}/>
         <h1 className="font-montserrat font-semibold text-[32px]">
             Detalle cotización


### PR DESCRIPTION
## 🚀 Objetivo

Corregir la visualización del **paso 2** en el flujo de cotización en el caso de que no hay cotizaciones seleccionadas, asegurando que el indicador numérico y los componentes relacionados muestren correctamente el número “2”.

---

## 📦 Cambios incluidos

<details>
<summary><strong>Archivos modificados (4)</strong></summary>

| Ruta                                             | Descripción                                                             |
|--------------------------------------------------|-------------------------------------------------------------------------|
| `src/components/NumberIcon.tsx`                  | Se amplió la lógica para soportar y renderizar el ícono con número 2 cuando no (para conseguir el mismo diseño estructural) hay cotizaciones seleccionadas.   |
| `src/components/cotizacion/CotizacionHeader.tsx` | Se añadió `NumberIcon(2)` en el encabezado del paso 2 con su descripción. |
| `src/components/cotizacion/CotizacionForm.tsx`   | Se incluyó `NumberIcon(2)` al inicio del formulario de cotización.      |
| `src/components/cotizacion/CotizacionBlocked.tsx`| Se ajustó el wrapper para mostrar el paso 2.  |
</details>

